### PR TITLE
[BUGFIX] Use EventInterface instead of ScenarioEvent in resetTextFixture...

### DIFF
--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -2,7 +2,7 @@
 namespace Flowpack\Behat\Tests\Behat;
 
 use Behat\Behat\Context\BehatContext;
-use Behat\Behat\Event\ScenarioEvent;
+use Behat\Behat\Event\EventInterface;
 use TYPO3\Flow\Core\Booting\Scripts,
 	TYPO3\Flow\Core\Bootstrap,
 	TYPO3\Flow\Configuration\ConfigurationManager;
@@ -94,9 +94,9 @@ class FlowContext extends BehatContext {
 	/**
 	 * @BeforeScenario @fixtures
 	 *
-	 * @param \Behat\Behat\Event\ScenarioEvent $event
+	 * @param \Behat\Behat\Event\EventInterface $event
 	 */
-	public function resetTestFixtures(ScenarioEvent $event) {
+	public function resetTestFixtures(EventInterface $event) {
 		/** @var \Doctrine\ORM\EntityManager $em */
 		$em = $this->objectManager->get('Doctrine\Common\Persistence\ObjectManager');
 		$em->clear();


### PR DESCRIPTION
...s

Depending on the context the resetTestFixtures() method will get different
types of arguments (Behat\Behat\Event\OutlineExampleEvent from a scenario
outline, Behat\Behat\Event\ScenarioEvent from a scenario). Thus it is necessary
to use an interface as parameter.
