### PR TITLE
[BUGFIX] Capturing console output must not prevent output rendering

### DIFF
--- a/Tests/Functional/Aop/ConsoleLoggingCaptureAspect.php
+++ b/Tests/Functional/Aop/ConsoleLoggingCaptureAspect.php
@@ -28,6 +28,11 @@ class ConsoleLoggingCaptureAspect {
 	protected $capturedOutput = '';
 
 	/**
+	 * @var boolean
+	 */
+	protected $sendConsoleOutput = FALSE;
+
+	/**
 	 * @Flow\Around("method(TYPO3\Flow\Cli\ConsoleOutput->output())")
 	 * @param JoinPointInterface $joinPoint
 	 */
@@ -39,6 +44,24 @@ class ConsoleLoggingCaptureAspect {
 		}
 
 		$this->capturedOutput .= $text;
+
+		if ($this->sendConsoleOutput === TRUE) {
+			return $joinPoint->getAdviceChain()->proceed($joinPoint);
+		}
+	}
+
+	/**
+	 * Enable console output
+	 */
+	public function enableOutput() {
+		$this->sendConsoleOutput = TRUE;
+	}
+
+	/**
+	 * Disable console output
+	 */
+	public function disableOutput() {
+		$this->sendConsoleOutput = FALSE;
 	}
 
 	/**


### PR DESCRIPTION
Currently the ConsoleLoggingCaptureAspect captures the console output,
but does not proceed in the advice chain. By this rendering of
cli output is completely prevented.
This change transforms the advice into a "Before" advice, which
will still capture the output. However the original method is
called afterwards and the output gets rendered as usual.