### PR TITLE
[BUGFIX] Capturing console output must not ultimatively prevent output rendering

### DIFF
--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -12,6 +12,7 @@ namespace Flowpack\Behat\Tests\Behat;
  *                                                                        */
 
 use Behat\Behat\Context\BehatContext;
+use Flowpack\Behat\Tests\Functional\Aop\ConsoleLoggingCaptureAspect;
 use TYPO3\Flow\Core\Booting\Scripts;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Configuration\ConfigurationManager;
@@ -42,6 +43,12 @@ class FlowContext extends BehatContext {
 	 * @var string
 	 */
 	protected $lastCommandOutput;
+
+	/**
+	 * @var ConsoleLoggingCaptureAspect
+	 * @Flow\Inject
+	 */
+	protected $consoleLoggingCaptureAspect;
 
 	/**
 	 * @param array $parameters
@@ -89,6 +96,8 @@ class FlowContext extends BehatContext {
 	 * @When /^(?:|I )run the command "([^"]*)"$/
 	 */
 	public function iRunTheCommand($command) {
+		$this->consoleLoggingCaptureAspect->disableOutput();
+
 		$captureAspect = $this->objectManager->get('Flowpack\Behat\Tests\Functional\Aop\ConsoleLoggingCaptureAspect');
 		$captureAspect->reset();
 
@@ -101,6 +110,8 @@ class FlowContext extends BehatContext {
 		$this->lastCommandOutput = $captureAspect->getCapturedOutput();
 
 		$this->persistAll();
+
+		$this->consoleLoggingCaptureAspect->enableOutput();
 	}
 
 	/**

--- a/Tests/Functional/Aop/ConsoleLoggingCaptureAspect.php
+++ b/Tests/Functional/Aop/ConsoleLoggingCaptureAspect.php
@@ -28,6 +28,11 @@ class ConsoleLoggingCaptureAspect {
 	protected $capturedOutput = '';
 
 	/**
+	 * @var boolean
+	 */
+	protected $sendConsoleOutput = FALSE;
+
+	/**
 	 * @Flow\Around("method(TYPO3\Flow\Cli\ConsoleOutput->output())")
 	 * @param JoinPointInterface $joinPoint
 	 */
@@ -39,6 +44,24 @@ class ConsoleLoggingCaptureAspect {
 		}
 
 		$this->capturedOutput .= $text;
+
+		if ($this->sendConsoleOutput === TRUE) {
+			return $joinPoint->getAdviceChain()->proceed($joinPoint);
+		}
+	}
+
+	/**
+	 * Enable console output
+	 */
+	public function enableOutput() {
+		$this->sendConsoleOutput = TRUE;
+	}
+
+	/**
+	 * Disable console output
+	 */
+	public function disableOutput() {
+		$this->sendConsoleOutput = FALSE;
 	}
 
 	/**

--- a/Tests/Functional/Aop/ConsoleLoggingCaptureAspect.php
+++ b/Tests/Functional/Aop/ConsoleLoggingCaptureAspect.php
@@ -30,7 +30,7 @@ class ConsoleLoggingCaptureAspect {
 	/**
 	 * @var boolean
 	 */
-	protected $sendConsoleOutput = FALSE;
+	protected $sendConsoleOutput = TRUE;
 
 	/**
 	 * @Flow\Around("method(TYPO3\Flow\Cli\ConsoleOutput->output())")


### PR DESCRIPTION
Currently the ConsoleLoggingCaptureAspect captures the console output,
but does not proceed in the advice chain. By this rendering of
cli output is completely prevented.
This change adds a function to enable the output manually. By this
the developer can decide in which cases the output should be
rendered.