### PR TITLE
[TASK] Replace classname strings with ::CLASS constants

### DIFF
--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -98,13 +98,13 @@ class FlowContext extends BehatContext {
 	public function iRunTheCommand($command) {
 		$this->consoleLoggingCaptureAspect->disableOutput();
 
-		$captureAspect = $this->objectManager->get('Flowpack\Behat\Tests\Functional\Aop\ConsoleLoggingCaptureAspect');
+		$captureAspect = $this->objectManager->get(\Flowpack\Behat\Tests\Functional\Aop\ConsoleLoggingCaptureAspect::CLASS);
 		$captureAspect->reset();
 
-		$request = $this->objectManager->get('TYPO3\Flow\Cli\RequestBuilder')->build($command);
+		$request = $this->objectManager->get(\TYPO3\Flow\Cli\RequestBuilder::CLASS)->build($command);
 		$response = new \TYPO3\Flow\Cli\Response();
 
-		$dispatcher = $this->objectManager->get('TYPO3\Flow\Mvc\Dispatcher');
+		$dispatcher = $this->objectManager->get(\TYPO3\Flow\Mvc\Dispatcher::CLASS);
 		$dispatcher->dispatch($request, $response);
 
 		$this->lastCommandOutput = $captureAspect->getCapturedOutput();
@@ -140,7 +140,7 @@ class FlowContext extends BehatContext {
 	 */
 	public function resetTestFixtures($event) {
 		/** @var \Doctrine\ORM\EntityManager $entityManager */
-		$entityManager = $this->objectManager->get('Doctrine\Common\Persistence\ObjectManager');
+		$entityManager = $this->objectManager->get(\Doctrine\Common\Persistence\ObjectManager::CLASS);
 		$entityManager->clear();
 
 		if (self::$databaseSchema !== NULL) {
@@ -148,15 +148,15 @@ class FlowContext extends BehatContext {
 		} else {
 			try {
 				/** @var \TYPO3\Flow\Persistence\Doctrine\Service $doctrineService */
-				$doctrineService = $this->objectManager->get('TYPO3\Flow\Persistence\Doctrine\Service');
+				$doctrineService = $this->objectManager->get(\TYPO3\Flow\Persistence\Doctrine\Service::CLASS);
 				$doctrineService->executeMigrations();
 				$needsTruncate = TRUE;
 			} catch (\Doctrine\DBAL\DBALException $exception) {
 				// Do an initial teardown to drop the schema cleanly
-				$this->objectManager->get('TYPO3\Flow\Persistence\PersistenceManagerInterface')->tearDown();
+				$this->objectManager->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::CLASS)->tearDown();
 
 				/** @var \TYPO3\Flow\Persistence\Doctrine\Service $doctrineService */
-				$doctrineService = $this->objectManager->get('TYPO3\Flow\Persistence\Doctrine\Service');
+				$doctrineService = $this->objectManager->get(\TYPO3\Flow\Persistence\Doctrine\Service::CLASS);
 				$doctrineService->executeMigrations();
 				$needsTruncate = FALSE;
 			}
@@ -216,11 +216,11 @@ class FlowContext extends BehatContext {
 	 */
 	protected function resetFactories() {
 		/** @var $reflectionService \TYPO3\Flow\Reflection\ReflectionService */
-		$reflectionService = $this->objectManager->get('TYPO3\Flow\Reflection\ReflectionService');
-		$fixtureFactoryClassNames = $reflectionService->getAllSubClassNamesForClass('Flowpack\Behat\Tests\Functional\Fixture\FixtureFactory');
-		foreach ($fixtureFactoryClassNames as $fixtureFactoyClassName) {
-			if (!$reflectionService->isClassAbstract($fixtureFactoyClassName)) {
-				$factory = $this->objectManager->get($fixtureFactoyClassName);
+		$reflectionService = $this->objectManager->get(\TYPO3\Flow\Reflection\ReflectionService::CLASS);
+		$fixtureFactoryClassNames = $reflectionService->getAllSubClassNamesForClass(\Flowpack\Behat\Tests\Functional\Fixture\FixtureFactory::CLASS);
+		foreach ($fixtureFactoryClassNames as $fixtureFactoryClassName) {
+			if (!$reflectionService->isClassAbstract($fixtureFactoryClassName)) {
+				$factory = $this->objectManager->get($fixtureFactoryClassName);
 				$factory->reset();
 			}
 		}
@@ -236,10 +236,10 @@ class FlowContext extends BehatContext {
 	 * @return void
 	 */
 	protected function resetRolesAndPolicyService() {
-		$this->objectManager->get('TYPO3\Flow\Security\Policy\PolicyService')->reset();
+		$this->objectManager->get(\TYPO3\Flow\Security\Policy\PolicyService::CLASS)->reset();
 
 		if ($this->objectManager->isRegistered('TYPO3\Flow\Security\Policy\RoleRepository')) {
-			$roleRepository = $this->objectManager->get('TYPO3\Flow\Security\Policy\RoleRepository');
+			$roleRepository = $this->objectManager->get(\TYPO3\Flow\Security\Policy\RoleRepository::CLASS);
 			\TYPO3\Flow\Reflection\ObjectAccess::setProperty($roleRepository, 'newRoles', array(), TRUE);
 		}
 	}
@@ -248,8 +248,8 @@ class FlowContext extends BehatContext {
 	 * Persist any changes
 	 */
 	public function persistAll() {
-		$this->objectManager->get('TYPO3\Flow\Persistence\PersistenceManagerInterface')->persistAll();
-		$this->objectManager->get('TYPO3\Flow\Persistence\PersistenceManagerInterface')->clearState();
+		$this->objectManager->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::CLASS)->persistAll();
+		$this->objectManager->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::CLASS)->clearState();
 
 		$this->resetFactories();
 	}
@@ -259,9 +259,9 @@ class FlowContext extends BehatContext {
 	 */
 	protected function getRouter() {
 		if ($this->router === NULL) {
-			$this->router = $this->objectManager->get('\TYPO3\Flow\Mvc\Routing\Router');
+			$this->router = $this->objectManager->get(\TYPO3\Flow\Mvc\Routing\Router::CLASS);
 
-			$configurationManager = $this->objectManager->get('TYPO3\Flow\Configuration\ConfigurationManager');
+			$configurationManager = $this->objectManager->get(\TYPO3\Flow\Configuration\ConfigurationManager::CLASS);
 			$routesConfiguration = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES);
 			$this->router->setRoutesConfiguration($routesConfiguration);
 		}


### PR DESCRIPTION
This replaces the use of class names in strings with using the ::CLASS
constant instead. This has the advantage of immediately being able to
spot errors (the class will be marked as undefined in any proper IDE)
and when refactoring the classes can be identified precisely. Also it
makes the use if namespace imports possible.