### PR TITLE
FIX: Add case for sqlite to truncate tables

### DIFF
--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -210,6 +210,12 @@ class FlowContext extends BehatContext {
 				$sql .= 'SET FOREIGN_KEY_CHECKS=1;';
 				$connection->executeQuery($sql);
 				break;
+			case 'sqlite':
+				foreach ($tables as $table) {
+					$sql = 'DELETE FROM `' . $table->getName() . '`;';
+					$connection->executeQuery($sql);
+				}
+				break;
 			case 'postgresql':
 			default:
 				foreach ($tables as $table) {


### PR DESCRIPTION
When behat tests are run on a sqlite database, resetting the fixtures will fail with an sql syntax error. This change adds a case for sqlite to truncateTables() as 'TRUNCATE' is
not available in sqlite but 'DELETE FROM' is used.